### PR TITLE
JSON General, Flattened and Document Serializations

### DIFF
--- a/examples/RS256-JWD.js
+++ b/examples/RS256-JWD.js
@@ -30,6 +30,7 @@ crypto.subtle
 
   // verify the signature
   .then(doc => {
+    console.log('DOCUMENT', doc)
     return JWD.verify(publicKey, doc)
   })
 

--- a/examples/RS256-JWD.js
+++ b/examples/RS256-JWD.js
@@ -1,0 +1,40 @@
+const crypto = require('webcrypto')
+const { JWD } = require('../src')
+
+let privateKey, publicKey
+
+let payload = { iss: 'hello world!' }
+let header = { alg: 'RS256', typ: 'JWS' }
+
+crypto.subtle
+
+  // use webcrypto to generate a keypair
+  .generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      hash: {
+        name: 'SHA-256'
+      }
+    },
+    true,
+    ['sign', 'verify']
+  )
+
+  // use key with JWA to create a signature
+  .then(keypair => {
+    privateKey = keypair.privateKey
+    publicKey = keypair.publicKey
+
+    return JWD.encode(privateKey, { signatures: [{ protected: header }], payload })
+  })
+
+  // verify the signature
+  .then(doc => {
+    return JWD.verify(publicKey, doc)
+  })
+
+  // look at the output
+  .then(doc => console.log(JSON.stringify(doc, null, 2)))
+
+  // look at the out
+  .catch(console.log)

--- a/examples/RS256-JWT-JWD-test.js
+++ b/examples/RS256-JWT-JWD-test.js
@@ -1,0 +1,79 @@
+const crypto = require('webcrypto')
+const { JWT, JWD } = require('../src')
+
+let privateKey, publicKey
+
+let payload = { iss: 'hello world!' }
+let header = { alg: 'RS256', typ: 'JWS' }
+
+crypto.subtle
+
+  // use webcrypto to generate a keypair
+  .generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      hash: {
+        name: 'SHA-256'
+      }
+    },
+    true,
+    ['sign', 'verify']
+  )
+
+  // use key with JWA to create a signature
+  .then(keypair => {
+    privateKey = keypair.privateKey
+    publicKey = keypair.publicKey
+
+    return Promise.all([
+      JWT.encode(privateKey, { header, payload }, { serialization: 'compact' }),
+      JWT.encode(privateKey, { protected: header, payload }, { serialization: 'flattened' }),
+      JWT.encode(privateKey, { signatures: [{ protected: header }], payload }, { serialization: 'json' }),
+      JWD.encode(privateKey, { signatures: [{ protected: header }], payload })
+    ])
+  })
+
+  // verify the signature
+  .then(tokens => {
+    console.log('TOKENS', tokens)
+    let [compact, flattened, json, doc] = tokens
+
+    return Promise.all([
+      JWT.verify(publicKey, compact),
+      JWT.verify(publicKey, flattened),
+      JWT.verify([publicKey], json),
+      JWD.verify([publicKey], doc)
+    ])
+  })
+
+  // look at the output
+  .then(tokens => {
+    // Print out tokens
+    tokens.map(token => console.log(JSON.stringify(token, null, 2)))
+
+    // Test if signatures match
+    console.log(tokens.reduce((prev, curr) => {
+      if (prev === false) {
+        return prev
+      }
+
+      let { signature, signatures } = curr
+
+      if (prev === true) {
+        if (signatures) {
+          return signatures[0].signature
+        } else {
+          return signature
+        }
+      } else {
+        if (prev === signature || (signatures && signatures[0].signature === prev)) {
+          return prev
+        } else {
+          return false
+        }
+      }
+    }, true) ? 'PASS: Signatures Match' : 'FAIL: Mismatched')
+  })
+
+  // look at the out
+  .catch(console.log)

--- a/examples/RS256-JWT.js
+++ b/examples/RS256-JWT.js
@@ -34,6 +34,7 @@ crypto.subtle
 
   // verify the signature
   .then(tokens => {
+    console.log('TOKENS', tokens)
     let [compact, flattened, json] = tokens
 
     return Promise.all([

--- a/examples/RS256-JWT.js
+++ b/examples/RS256-JWT.js
@@ -28,7 +28,7 @@ crypto.subtle
     return Promise.all([
       JWT.encode(privateKey, { header, payload }, { serialization: 'compact' }),
       JWT.encode(privateKey, { protected: header, payload }, { serialization: 'flattened' }),
-      JWT.encode([privateKey], { signatures: [{ protected: header }], payload }, { serialization: 'json' })
+      JWT.encode(privateKey, { signatures: [{ protected: header }], payload }, { serialization: 'json' })
     ])
   })
 
@@ -39,7 +39,7 @@ crypto.subtle
     return Promise.all([
       JWT.verify(publicKey, compact),
       JWT.verify(publicKey, flattened),
-      JWT.verify(publicKey, json)
+      JWT.verify([publicKey], json)
     ])
   })
 

--- a/examples/RS256-JWT.js
+++ b/examples/RS256-JWT.js
@@ -1,0 +1,51 @@
+const crypto = require('webcrypto')
+const { JWT } = require('../src')
+
+let privateKey, publicKey
+
+let payload = { iss: 'hello world!' }
+let header = { alg: 'RS256', typ: 'JWS' }
+
+crypto.subtle
+
+  // use webcrypto to generate a keypair
+  .generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      hash: {
+        name: 'SHA-256'
+      }
+    },
+    true,
+    ['sign', 'verify']
+  )
+
+  // use key with JWA to create a signature
+  .then(keypair => {
+    privateKey = keypair.privateKey
+    publicKey = keypair.publicKey
+
+    return Promise.all([
+      JWT.encode(privateKey, { header, payload }, { serialization: 'compact' }),
+      JWT.encode(privateKey, { protected: header, payload }, { serialization: 'flattened' }),
+      JWT.encode([privateKey], { signatures: [{ protected: header }], payload }, { serialization: 'json' })
+    ])
+  })
+
+  // verify the signature
+  .then(tokens => {
+    let [compact, flattened, json] = tokens
+
+    return Promise.all([
+      JWT.verify(publicKey, compact),
+      JWT.verify(publicKey, flattened),
+      JWT.verify(publicKey, json)
+    ])
+  })
+
+  // look at the output
+  .then(tokens => tokens.map(token => console.log(JSON.stringify(token, null, 2))))
+  // .then(console.log)
+
+  // look at the out
+  .catch(console.log)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "homepage": "https://github.com/anvilresearch/jose#README",
   "dependencies": {
     "base64url": "^1.0.6",
-    "json-document": "0.0.1",
+    "json-document": "^0.1.1",
     "text-encoding": "^0.6.1",
     "webcrypto": "git://github.com/anvilresearch/webcrypto.git"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const JWA = require('./jose/JWA')
 const JWK = require('./jose/JWK')
 const JWKSet = require('./jose/JWKSet')
 const JWT = require('./jose/JWT')
+const JWD = require('./jose/JWD')
 const JWS = require('./jose/JWS')
 const Base64URLSchema = require('./schemas/Base64URLSchema')
 const JOSEHeaderSchema = require('./schemas/JOSEHeaderSchema')
@@ -22,6 +23,7 @@ module.exports = {
   JWK,
   JWKSet,
   JWT,
+  JWD,
   JWS,
   Base64URLSchema,
   JOSEHeaderSchema,

--- a/src/jose/JWD.js
+++ b/src/jose/JWD.js
@@ -1,0 +1,253 @@
+/**
+ * Dependencies
+ */
+const base64url = require('base64url')
+const {JSONDocument} = require('json-document')
+const JWDSchema = require('../schemas/JWDSchema')
+const JWS = require('./JWS')
+const DataError = require('../errors/DataError')
+
+/**
+ * JWD
+ */
+class JWD extends JSONDocument {
+
+  /**
+   * schema
+   */
+  static get schema () {
+    return JWDSchema
+  }
+
+  /**
+   * decode
+   *
+   * @description
+   * Decode a JSON Web Document
+   *
+   * @param {String} data
+   *
+   * @returns {Promise<JWD>}
+   */
+  static decode (data) {
+    let ExtendedJWD = this
+
+    if (typeof data !== 'string') {
+      return Promise.reject(new DataError('JWD must be a string'))
+    }
+
+    try {
+      data = JSON.parse(data)
+    } catch (error) {
+      return Promise.reject(new DataError('Invalid JWD'))
+    }
+
+    let doc = new ExtendedJWD(data)
+
+    Object.defineProperty(doc, 'serialization', { value: 'document', enumerable: false })
+    Object.defineProperty(doc, 'type', { value: 'JWS', enumerable: false })
+
+    return Promise.resolve(doc)
+  }
+
+  /**
+   * encode
+   *
+   * @description
+   * Encode a JSON Web Document
+   *
+   * @param {CryptoKey|Object} key
+   * @param {CryptoKey} key.sign
+   * @param {CryptoKey} key.encrypt
+   * @param {Object} data
+   * @param {Object} [options]
+   *
+   * @returns {Promise<SerializedToken>}
+   */
+  static encode (key, data, options={}) {
+    let ExtendedJWD = this
+    let doc = new ExtendedJWD(data)
+
+    if (!key) {
+      return Promise.reject(new DataError('Key required to encode JWD'))
+    }
+
+    // Assign options to JWD as nonenumerable properties
+    Object.keys(options).forEach(field => {
+      Object.defineProperty(doc, field, { value: options[field], enumerable: false })
+    })
+
+    if (key.encrypt) {
+      // TODO Encryption
+      // Object.defineProperty(descriptor, 'encryption_key', {
+      //   value: key.encrypt,
+      //   enumerable: false
+      // })
+    }
+
+    let { signatures } = doc
+
+    // Assign key to new signature
+    doc.signatures = signatures.map(descriptor => {
+
+      if (!descriptor.signature) {
+        Object.defineProperty(descriptor, 'key', { value: key.sign ? key.sign : key, enumerable: false })
+      }
+
+      return descriptor
+    })
+
+    if (!doc.serialzation) {
+      Object.defineProperty(doc, 'serialization', { value: 'document', enumerable: false })
+    }
+
+    return doc.encode()
+  }
+
+
+  /**
+   * verify
+   *
+   * @description
+   * Decode and verify a JSON Web Token
+   *
+   * @param {CryptoKey|Array<CryptoKey>} key
+   * @param {String} data
+   * @param {Object} [options]
+   *
+   * @returns {Promise<JWD>}
+   */
+  static verify (key, data, options={}) {
+    let ExtendedJWD = this
+    let jwd
+
+    // Decode
+    return ExtendedJWD.decode(data).then(doc => {
+      let { signatures } = doc
+      jwd = doc
+
+      // Assign options to JWD as nonenumerable properties
+      Object.keys(options).forEach(field => {
+        Object.defineProperty(doc, field, { value: options[field], enumerable: false })
+      })
+
+      // Map keys to signatures by index
+      if (Array.isArray(key) && signatures) {
+        doc.signatures = signatures.map((descriptor, index) => {
+          // TODO more sophisticated key mapping using hints like `kid'
+          if (index < key.length) {
+            Object.defineProperty(descriptor, 'key', { value: key[index], enumerable: false })
+          }
+
+          return descriptor
+        })
+
+      // Assign single key to all signatures as nonenumerable property
+      } else if (signatures) {
+        doc.signatures = signatures.map(descriptor => {
+          Object.defineProperty(descriptor, 'key', { value: key, enumerable: false })
+          return descriptor
+        })
+
+      // Assign key to document as nonenumerable property
+      } else {
+        Object.defineProperty(doc, 'key', { value: key, enumerable: false })
+      }
+
+      return doc.verify()
+    }).then(verified => jwd)
+  }
+
+  /**
+   * isJWE
+   */
+  isJWE () {
+    let { header: unprotectedHeader, protected: protectedHeader, recipients } = this
+    return !!((unprotectedHeader && unprotectedHeader.enc)
+      || (protectedHeader && protectedHeader.enc)
+      || recipients)
+  }
+
+  /**
+   * resolveKeys
+   */
+  resolveKeys (jwks) {
+    let kid = this.header.kid
+    let keys, match
+
+    // treat an array as the "keys" property of a JWK Set
+    if (Array.isArray(jwks)) {
+      keys = jwks
+    }
+
+    // presence of keys indicates object is a JWK Set
+    if (jwks.keys) {
+      keys = jwks.keys
+    }
+
+    // wrap a plain object they is not a JWK Set in Array
+    if (!jwks.keys && typeof jwks === 'object') {
+      keys = [jwks]
+    }
+
+    // ensure there are keys to search
+    if (!keys) {
+      throw new DataError('Invalid JWK argument')
+    }
+
+    // match by "kid" or "use" header
+    if (kid) {
+      match = keys.find(jwk => jwk.kid === kid)
+    } else {
+      match = keys.find(jwk => jwk.use === 'sig')
+    }
+
+    // assign matching key to JWD and return a boolean
+    if (match) {
+      console.log(match)
+      this.key = match.cryptoKey
+      return true
+    } else {
+      return false
+    }
+  }
+
+  /**
+   * encode
+   *
+   * @description
+   * Encode a JSON Web Token instance
+   *
+   * @returns {Promise<SerializedToken>}
+   */
+  encode () {
+    let validation = this.validate()
+
+    if (!validation.valid) {
+      return Promise.reject(validation)
+    }
+
+    if (this.isJWE()) {
+      return JWE.encrypt(this)
+    } else {
+      return JWS.sign(this)
+    }
+  }
+
+  /**
+   * verify
+   *
+   * @description
+   * Verify a decoded JSON Web Token instance
+   *
+   * @returns {Promise<Boolean>}
+   */
+  verify () {
+    return JWS.verify(this)
+  }
+}
+
+/**
+ * Export
+ */
+module.exports = JWD

--- a/src/jose/JWS.js
+++ b/src/jose/JWS.js
@@ -77,7 +77,33 @@ class JWS {
     }
 
     if (serialization === 'document') {
-      // TODO
+      let { signatures } = token
+
+      let promises = signatures.map(descriptor => {
+        let { header: unprotectedHeader, protected: protectedHeader, signature, key } = descriptor
+        let { alg } = protectedHeader
+
+        // Attempt to use existing signature
+        if (signature && !key) {
+          return Promise.resolve(descriptor)
+
+        } else if (signature && key) {
+          // TODO
+
+        // Create new signature
+        } else {
+          let encodedHeader = base64url(JSON.stringify(protectedHeader))
+          let data = `${encodedHeader}.${encodedPayload}`
+
+          return JWA.sign(alg, key, data).then(signature => {
+            return { protected: protectedHeader, header: unprotectedHeader, signature }
+          })
+        }
+      })
+
+      return Promise.all(promises).then(signatures => {
+        return JSON.stringify({ payload, signatures })
+      })
     }
 
     return Promise.reject(new DataError('Unsupported serialization'))

--- a/src/jose/JWT.js
+++ b/src/jose/JWT.js
@@ -252,9 +252,10 @@ class JWT extends JSONDocument {
    * isJWE
    */
   isJWE () {
-    let { header: unprotectedHeader, protected: protectedHeader } = this
+    let { header: unprotectedHeader, protected: protectedHeader, recipients } = this
     return !!((unprotectedHeader && unprotectedHeader.enc)
-      || (protectedHeader && protectedHeader.enc))
+      || (protectedHeader && protectedHeader.enc)
+      || recipients)
   }
 
   /**

--- a/src/jose/JWT.js
+++ b/src/jose/JWT.js
@@ -172,6 +172,15 @@ class JWT extends JSONDocument {
       Object.defineProperty(token, field, { value: options[field], enumerable: false })
     })
 
+    // Default to compact serialization or json serialization (multiple signatures)
+    if (!token.serialization) {
+      if (token.signatures) {
+        Object.defineProperty(token, 'serialization', { value: 'json', enumerable: false })
+      } else {
+        Object.defineProperty(token, 'serialization', { value: 'compact', enumerable: false })
+      }
+    }
+
     // Multiple Signatures/Keys
     if (token.signatures) {
       let { signatures } = token

--- a/src/schemas/JOSEHeaderSchema.js
+++ b/src/schemas/JOSEHeaderSchema.js
@@ -159,7 +159,7 @@ const JOSEHeaderSchema = new JSONSchema({
      */
     cty: {
       type: 'string',
-      enum: ['JWT']
+      enum: ['JWT', 'JWD']
     },
 
     /**

--- a/src/schemas/JWDSchema.js
+++ b/src/schemas/JWDSchema.js
@@ -1,0 +1,41 @@
+/**
+ * Dependencies
+ */
+const Base64URLSchema = require('./Base64URLSchema')
+const JWTClaimsSetSchema = require('./JWTClaimsSetSchema')
+const JOSEHeaderSchema = require('./JOSEHeaderSchema')
+const {JSONSchema} = require('json-document')
+
+/**
+ * JWDSchema
+ */
+const JWDSchema = new JSONSchema({
+  type: 'object',
+  properties: {
+
+    /**
+     * payload
+     */
+    payload: JWTClaimsSetSchema,
+
+    /**
+     * signatures
+     */
+    signatures: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          protected: JOSEHeaderSchema,
+          header: { type: 'object' },
+          signature: Base64URLSchema
+        }
+      }
+    }
+  }
+})
+
+/**
+ * Export
+ */
+module.exports = JWDSchema

--- a/src/schemas/JWTClaimsSetSchema.js
+++ b/src/schemas/JWTClaimsSetSchema.js
@@ -29,7 +29,7 @@ const {JSONSchema} = require('json-document')
  *   Public Claim Names, and Private Claim Names.
  */
 const JWTClaimsSetSchema = new JSONSchema({
-  additionalProperties: true,
+  // additionalProperties: true,
   properties: {
 
     /**

--- a/src/schemas/JWTClaimsSetSchema.js
+++ b/src/schemas/JWTClaimsSetSchema.js
@@ -29,6 +29,7 @@ const {JSONSchema} = require('json-document')
  *   Public Claim Names, and Private Claim Names.
  */
 const JWTClaimsSetSchema = new JSONSchema({
+  additionalProperties: true,
   properties: {
 
     /**

--- a/src/schemas/JWTSchema.js
+++ b/src/schemas/JWTSchema.js
@@ -78,8 +78,7 @@ const JWTSchema = new JSONSchema({
         properties: {
           protected: JOSEHeaderSchema,
           header: JOSEHeaderSchema,
-          signature: Base64URLSchema,
-          key: { type: 'object' }
+          signature: Base64URLSchema
         }
       }
     },

--- a/src/schemas/JWTSchema.js
+++ b/src/schemas/JWTSchema.js
@@ -20,21 +20,6 @@ const JWTSchema = new JSONSchema({
   properties: {
 
     /**
-     * type
-     */
-    type: {
-      type: 'string',
-      enum: ['JWS', 'JWE']
-    },
-
-    /**
-     * segments
-     */
-    segments: {
-      type: 'array'
-    },
-
-    /**
      * header
      */
     header: JOSEHeaderSchema,
@@ -43,11 +28,6 @@ const JWTSchema = new JSONSchema({
      * protected
      */
     protected: JOSEHeaderSchema,
-
-    /**
-     * unprotected
-     */
-    unprotected: JOSEHeaderSchema,
 
     /**
      * iv
@@ -108,30 +88,6 @@ const JWTSchema = new JSONSchema({
      * signature
      */
     signature: Base64URLSchema,
-
-    /**
-     * verified
-     */
-    verified: {
-      type: 'boolean',
-      default: false
-    },
-
-    /**
-     * key
-     */
-    key: {
-      type: 'object'
-    },
-
-    /**
-     * serialization
-     */
-    serialization: {
-      type: 'string',
-      enum: ['compact', 'json', 'flattened'],
-      default: 'compact'
-    }
   }
 })
 

--- a/test/jose/JWDSpec.js
+++ b/test/jose/JWDSpec.js
@@ -31,10 +31,10 @@ const doc = {
   signatures: [
     {
       protected: {
-        alg: "RS256",
-        typ: "JWS"
+        typ: "JWS",
+        alg: "RS256"
       },
-      signature: "hOKzfFHDXWfrOoJEj5LAB6LYgiu4jebRoUbsJFn7sNKgDh3aTMKE2t-oZAV9QxjfEiHzpQIrMSEa-Kl8sytkhSzi7m01zp178VhcIglL7JGLZVPDdpq7cBQ1wuAk5tPrRRfZxaU97bhA9g110BVP4fmQi4PDBhAroIUXizwIrSJ5Vpi74yEpJjHYB4_iZc576Eajqw3cZdLgFCGeDKEJ-Rzir6l7HrNm1SaOGjgMEmSE9KxRBvQcIo5OdjH0nX0mErCjbhJrvvBkYqy5mHfWbtnr_mfE9PRp6NLqVH99IKDeReoXHw6118x_27YsqnrGDQ4wMGzodVaonwRSW8Yanw"
+      signature: "Z9kDlLsluttzQKqd2HSHdNB6WNmjIcesP5DkfCeX7EqYNAugjBatXLOTV8w1FuYUQBxowox-Sem6xbecTLu8d8sESNEzrnF_BUtROJ8eA1vOjSvTzi_mW0DG6p-IXXOQ0UznVmo5hy87kJnYovnwCBY2ZmZT6SkKs4-_22Fnw8PvYG5zN_ev0Q3Hh4F6L8sa5Wk3Maa6UKt8yS0UZR42_vlTWK-10cFqKElbPbsCaU__0yx-O_LdmEo7fpd4n_9ghz58_OhFFZIZuXPxf8a4bZGZGLr0ZWeWzbs2igQ-AbynPibDs9MAyOLB82Y9ZC4i5gcWzThcEhAe9LrCQEf14A"
     }
   ]
 }

--- a/test/jose/JWDSpec.js
+++ b/test/jose/JWDSpec.js
@@ -1,0 +1,183 @@
+'use strict'
+
+/**
+ * Test dependencies
+ */
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+
+/**
+ * Assertions
+ */
+chai.use(chaiAsPromised)
+chai.should()
+let expect = chai.expect
+
+/**
+ * Code under test
+ */
+const crypto = require('webcrypto')
+const { JWD } = require('../../src')
+const JWDSchema = require('../../src/schemas/JWDSchema')
+const { RsaPrivateCryptoKey, RsaPublicCryptoKey } = require('../keys')
+
+/**
+ * Test data
+ */
+const doc = {
+  payload: {
+    iss: "hello world!"
+  },
+  signatures: [
+    {
+      protected: {
+        alg: "RS256",
+        typ: "JWS"
+      },
+      signature: "hOKzfFHDXWfrOoJEj5LAB6LYgiu4jebRoUbsJFn7sNKgDh3aTMKE2t-oZAV9QxjfEiHzpQIrMSEa-Kl8sytkhSzi7m01zp178VhcIglL7JGLZVPDdpq7cBQ1wuAk5tPrRRfZxaU97bhA9g110BVP4fmQi4PDBhAroIUXizwIrSJ5Vpi74yEpJjHYB4_iZc576Eajqw3cZdLgFCGeDKEJ-Rzir6l7HrNm1SaOGjgMEmSE9KxRBvQcIo5OdjH0nX0mErCjbhJrvvBkYqy5mHfWbtnr_mfE9PRp6NLqVH99IKDeReoXHw6118x_27YsqnrGDQ4wMGzodVaonwRSW8Yanw"
+    }
+  ]
+}
+const { payload, signatures: [ signatureDescriptor ] } = doc
+const { protected: protectedHeader, signature } = signatureDescriptor
+const serializedToken = JSON.stringify(doc)
+
+/**
+ * Tests
+ */
+describe('JWD', () => {
+
+  /**
+   * schema
+   */
+  describe('schema', () => {
+    it('should return JWDSchema', () => {
+      JWD.schema.should.equal(JWDSchema)
+    })
+  })
+
+  /**
+   * static decode
+   */
+  describe('static decode', () => {
+    describe('non-string argument', () => {
+      it('should reject with a DataError', (done) => {
+        JWD.decode(false)
+          .should.be.rejectedWith('JWD must be a string').and.notify(done)
+      })
+    })
+
+    describe('Document Serialization', () => {
+      it('should reject with a DataError', (done) => {
+        JWD.decode('wrong')
+          .should.be.rejectedWith('Invalid JWD').and.notify(done)
+      })
+
+      it('should return a JWD instance', (done) => {
+        JWD.decode(serializedToken)
+          .should.eventually.be.instanceof(JWD).and.notify(done)
+      })
+
+      it('should set JWD type', (done) => {
+        JWD.decode(serializedToken).should.eventually.have.property('type')
+          .that.equals('JWS').and.notify(done)
+      })
+
+      it('should set JWD payload', (done) => {
+        JWD.decode(serializedToken)
+          .should.eventually.deep.have.property('payload')
+          .that.equals(payload).and.notify(done)
+      })
+
+      it('should set JWD serialization', (done) => {
+        JWD.decode(serializedToken)
+          .should.eventually.deep.have.property('serialization')
+          .that.equals('document').and.notify(done)
+      })
+
+      it('should set JWD signatures', (done) => {
+        JWD.decode(serializedToken)
+          .should.eventually.have.property('signatures')
+          .that.deep.includes(signatureDescriptor).and.notify(done)
+      })
+
+      describe('signatures', () => {
+
+        it('should set JWD protected header', (done) => {
+          JWD.decode(serializedToken).then(token => token.signatures[0])
+            .should.eventually.have.property('protected')
+            .that.deep.equals(protectedHeader).and.notify(done)
+        })
+
+        it('should set JWD signature', (done) => {
+          JWD.decode(serializedToken).then(token => token.signatures[0])
+            .should.eventually.have.property('signature')
+            .that.deep.equals(signature).and.notify(done)
+        })
+      })
+    })
+  })
+
+  describe('static encode', () => {})
+  describe('static sign', () => {})
+  describe('static verify', () => {})
+
+  describe('isJWE', () => {
+    it('should return true with "recipients" field')
+  })
+
+  /**
+   * resolveKeys
+   */
+  describe('resolveKeys', () => {
+    it('should throw with invalid argument')
+    it('should return true with match')
+    it('should return false with no match')
+    it('should match JWK by `kid`')
+    it('should match JWK by `use`')
+  })
+
+  /**
+   * encode
+   */
+  describe('encode', () => {
+    it('should reject invalid JWD', (done) => {
+      let jwd = new JWD({
+        header: { alg: 'RS256', kid: 'r4nd0mbyt3s' },
+        payload: { iss: null },
+        key: RsaPrivateCryptoKey
+      })
+
+      jwd.encode().should.be.rejected.and.notify(done)
+    })
+
+    it('should resolve a stringified JWD', (done) => {
+      JWD.encode(RsaPrivateCryptoKey, {
+        payload: { iss: 'hello world!' },
+        signatures: [{ protected: { alg: 'RS256', typ: 'JWS' } }],
+      }).should.eventually.equal(serializedToken).and.notify(done)
+    })
+  })
+
+  /**
+   * verify
+   */
+  describe('verify', () => {
+    it('should reject invalid JWD', (done) => {
+      let jwd = new JWD({
+        header: { alg: 'RS256', kid: 'r4nd0mbyt3s' },
+        payload: { iss: null },
+        key: RsaPrivateCryptoKey
+      })
+
+      jwd.verify().should.be.rejected.and.notify(done)
+    })
+
+    it('should resolve a boolean', (done) => {
+      JWD.verify(RsaPublicCryptoKey, serializedToken)
+        .then(jwd => {
+          jwd.verify().should.eventually.equal(true).and.notify(done)
+        })
+    })
+  })
+})

--- a/test/jose/JWDSpec.js
+++ b/test/jose/JWDSpec.js
@@ -61,58 +61,60 @@ describe('JWD', () => {
    */
   describe('static decode', () => {
     describe('non-string argument', () => {
-      it('should reject with a DataError', (done) => {
-        JWD.decode(false)
-          .should.be.rejectedWith('JWD must be a string').and.notify(done)
+      it('should throw with a DataError', () => {
+        expect(() => {
+          JWD.decode(false)
+        }).to.throw('JWD must be a string')
       })
     })
 
     describe('Document Serialization', () => {
-      it('should reject with a DataError', (done) => {
-        JWD.decode('wrong')
-          .should.be.rejectedWith('Invalid JWD').and.notify(done)
+      it('should throw with a DataError', () => {
+        expect(() => {
+          JWD.decode('wrong')
+        }).to.throw('Invalid JWD')
       })
 
-      it('should return a JWD instance', (done) => {
+      it('should return a JWD instance', () => {
         JWD.decode(serializedToken)
-          .should.eventually.be.instanceof(JWD).and.notify(done)
+          .should.be.instanceof(JWD)
       })
 
-      it('should set JWD type', (done) => {
-        JWD.decode(serializedToken).should.eventually.have.property('type')
-          .that.equals('JWS').and.notify(done)
+      it('should set JWD type', () => {
+        JWD.decode(serializedToken).should.have.property('type')
+          .that.equals('JWS')
       })
 
-      it('should set JWD payload', (done) => {
+      it('should set JWD payload', () => {
         JWD.decode(serializedToken)
-          .should.eventually.deep.have.property('payload')
-          .that.equals(payload).and.notify(done)
+          .should.deep.have.property('payload')
+          .that.equals(payload)
       })
 
-      it('should set JWD serialization', (done) => {
+      it('should set JWD serialization', () => {
         JWD.decode(serializedToken)
-          .should.eventually.deep.have.property('serialization')
-          .that.equals('document').and.notify(done)
+          .should.deep.have.property('serialization')
+          .that.equals('document')
       })
 
-      it('should set JWD signatures', (done) => {
+      it('should set JWD signatures', () => {
         JWD.decode(serializedToken)
-          .should.eventually.have.property('signatures')
-          .that.deep.includes(signatureDescriptor).and.notify(done)
+          .should.have.property('signatures')
+          .that.deep.includes(signatureDescriptor)
       })
 
       describe('signatures', () => {
 
-        it('should set JWD protected header', (done) => {
-          JWD.decode(serializedToken).then(token => token.signatures[0])
-            .should.eventually.have.property('protected')
-            .that.deep.equals(protectedHeader).and.notify(done)
+        it('should set JWD protected header', () => {
+          JWD.decode(serializedToken).signatures[0]
+            .should.have.property('protected')
+            .that.deep.equals(protectedHeader)
         })
 
-        it('should set JWD signature', (done) => {
-          JWD.decode(serializedToken).then(token => token.signatures[0])
-            .should.eventually.have.property('signature')
-            .that.deep.equals(signature).and.notify(done)
+        it('should set JWD signature', () => {
+          JWD.decode(serializedToken).signatures[0]
+            .should.have.property('signature')
+            .that.deep.equals(signature)
         })
       })
     })

--- a/test/jose/JWTSpec.js
+++ b/test/jose/JWTSpec.js
@@ -49,158 +49,139 @@ describe('JWT', () => {
    */
   describe('static decode', () => {
     describe('non-string argument', () => {
-      it('should reject with a DataError', (done) => {
-        JWT.decode(false).should.be.rejectedWith('JWT must be a string').and.notify(done)
+      it('should throw with a DataError', () => {
+        expect(() => {
+          JWT.decode(false)
+        }).to.throw('JWT must be a string')
       })
     })
 
     describe('JWS JSON Serialization', () => {
-      it('should return a promise', (done) => {
-        JWT.decode(json).should.be.fulfilled.and.notify(done)
+      it('should throw malformed JWT', () => {
+        expect(() => {
+          JWT.decode('{wrong}')
+        }).to.throw('Invalid JWT serialization')
       })
 
-      it('should throw malformed JWT', (done) => {
-        JWT.decode('{wrong}')
-          .should.be.rejectedWith('Invalid JWT serialization')
-          .and.notify(done)
+      it('should return an instance', () => {
+        JWT.decode(json).should.be.instanceof(JWT)
       })
 
-      it('should resolve a JWT instance', (done) => {
-        JWT.decode(json).should.eventually.be.instanceof(JWT)
-          .and.notify(done)
+      it('should set JWT type', () => {
+        JWT.decode(json).should.have.property('type').that.equals('JWS')
       })
 
-      it('should set JWT type', (done) => {
-        JWT.decode(json).should.eventually.have.property('type')
-          .that.equals('JWS').and.notify(done)
-      })
-
-      it('should set JWT payload', (done) => {
-        JWT.decode(json).should.eventually.have.property('payload')
+      it('should set JWT payload', () => {
+        JWT.decode(json).should.have.property('payload')
           .that.deep.equals({ iss: 'https://forge.anvil.io' })
-          .and.notify(done)
       })
 
-      it('should set JWT serialization', (done) => {
-        JWT.decode(json).should.eventually.have.property('serialization')
+      it('should set JWT serialization', () => {
+        JWT.decode(json).should.have.property('serialization')
           .that.equals('json')
-          .and.notify(done)
       })
 
-      it('should set JWT signatures', (done) => {
-        JWT.decode(json).should.eventually.have.property('signatures')
-          .and.notify(done)
+      it('should set JWT signatures', () => {
+        JWT.decode(json).should.have.property('signatures')
       })
 
       describe('signatures', () => {
 
-        it('should set JWT protected header', (done) => {
-          JWT.decode(json).then(token => token.signatures[0])
-            .should.eventually.have.property('protected')
-            .that.deep.equals({ alg: 'RS256', kid: 'r4nd0mbyt3s' }).and.notify(done)
+        it('should set JWT protected header', () => {
+          JWT.decode(json).signatures[0].should.have.property('protected')
+            .that.deep.equals({ alg: 'RS256', kid: 'r4nd0mbyt3s' })
         })
 
-        it('should set JWT signature', (done) => {
-          JWT.decode(json).then(token => token.signatures[0])
-            .should.eventually.have.property('signature')
-            .that.deep.equals(signature).and.notify(done)
+        it('should set JWT signature', () => {
+          JWT.decode(json).signatures[0].should.have.property('signature')
+            .that.deep.equals(signature)
         })
       })
     })
 
     describe('JWS Flattened JSON Serialization', () => {
-      it('should return a promise', (done) => {
-        JWT.decode(flattened).should.be.fulfilled.and.notify(done)
+      it('should throw malformed JWT', () => {
+        expect(() => {
+          JWT.decode('{wrong}')
+        }).to.throw('Invalid JWT serialization')
       })
 
-      it('should reject malformed JWT', (done) => {
-        JWT.decode('{wrong}')
-          .should.be.rejectedWith('Invalid JWT serialization')
-          .and.notify(done)
+      it('should return a JWT instance', () => {
+        JWT.decode(flattened).should.be.instanceof(JWT)
       })
 
-      it('should resolve a JWT instance', (done) => {
-        JWT.decode(flattened).should.eventually.be.instanceof(JWT)
-          .and.notify(done)
+      it('should set JWT type', () => {
+        JWT.decode(flattened).should.have.property('type').that.equals('JWS')
       })
 
-      it('should set JWT type', (done) => {
-        JWT.decode(flattened).should.eventually.have.property('type')
-          .that.equals('JWS').and.notify(done)
-      })
-
-      it('should set JWT protected header', (done) => {
-        JWT.decode(flattened).should.eventually.have.property('protected')
+      it('should set JWT protected header', () => {
+        JWT.decode(flattened).should.have.property('protected')
           .that.deep.equals({ alg: 'RS256', kid: 'r4nd0mbyt3s' })
-          .and.notify(done)
       })
 
-      it('should set JWT payload', (done) => {
-        JWT.decode(flattened).should.eventually.have.property('payload')
+      it('should set JWT payload', () => {
+        JWT.decode(flattened).should.have.property('payload')
           .that.deep.equals({ iss: 'https://forge.anvil.io' })
-          .and.notify(done)
+
       })
 
-      it('should set JWT signature', (done) => {
-        JWT.decode(flattened).should.eventually.have.property('signature')
+      it('should set JWT signature', () => {
+        JWT.decode(flattened).should.have.property('signature')
           .that.equals(signature)
-          .and.notify(done)
+
       })
 
-      it('should set JWT serialization', (done) => {
-        JWT.decode(flattened).should.eventually.have.property('serialization')
+      it('should set JWT serialization', () => {
+        JWT.decode(flattened).should.have.property('serialization')
           .that.equals('flattened')
-          .and.notify(done)
+
       })
     })
 
     describe('JWS Compact Serialization', () => {
-      it('should return a promise', (done) => {
-        JWT.decode(compact).should.be.fulfilled.and.notify(done)
+      it('should reject malformed JWT with a DataError', () => {
+        expect(() => {
+          JWT.decode('wrong')
+        }).to.throw('Invalid JWT compact serialization')
+
       })
 
-      it('should reject malformed JWT with a DataError', (done) => {
-        JWT.decode('wrong').should.be.rejectedWith('Malformed JWT')
-          .and.notify(done)
+      it('should return a JWT instance', () => {
+        JWT.decode(compact).should.be.instanceof(JWT)
       })
 
-      it('should return a JWT instance', (done) => {
-        JWT.decode(compact).should.eventually.be.instanceof(JWT)
-          .and.notify(done)
+      it('should set JWT type', () => {
+        JWT.decode(compact).should.have.property('type')
+          .that.equals('JWS')
       })
 
-      it('should set JWT type', (done) => {
-        JWT.decode(compact).should.eventually.have.property('type')
-          .that.equals('JWS').and.notify(done)
+      it('should set JWT segments', () => {
+        JWT.decode(compact).should.have.property('segments')
+          .that.deep.equals(compact.split('.'))
       })
 
-      it('should set JWT segments', (done) => {
-        JWT.decode(compact).should.eventually.have.property('segments')
-          .that.deep.equals(compact.split('.')).and.notify(done)
-      })
-
-      it('should set JWT header', (done) => {
-        JWT.decode(compact).should.eventually.have.property('header')
+      it('should set JWT header', () => {
+        JWT.decode(compact).should.have.property('header')
           .that.deep.equals({ alg: 'RS256', kid: 'r4nd0mbyt3s' })
-          .and.notify(done)
+
       })
 
-      it('should set JWT payload', (done) => {
-        JWT.decode(compact).should.eventually.have.property('payload')
+      it('should set JWT payload', () => {
+        JWT.decode(compact).should.have.property('payload')
           .that.deep.equals({ iss: 'https://forge.anvil.io' })
-          .and.notify(done)
+
       })
 
-      it('should set JWT signature', (done) => {
-        JWT.decode(compact).should.eventually.have.property('signature')
+      it('should set JWT signature', () => {
+        JWT.decode(compact).should.have.property('signature')
           .that.equals(signature)
-          .and.notify(done)
+
       })
 
-      it('should set JWT serialization', (done) => {
-        JWT.decode(compact).should.eventually.have.property('serialization')
+      it('should set JWT serialization', () => {
+        JWT.decode(compact).should.have.property('serialization')
           .that.equals('compact')
-          .and.notify(done)
+
       })
     })
   })
@@ -294,7 +275,8 @@ describe('JWT', () => {
   describe('verify', () => {
     it('should reject invalid JWT', (done) => {
       JWT.verify(RsaPublicCryptoKey, 'invalid')
-        .should.be.rejected.and.notify(done)
+        .should.be.rejectedWith('Invalid JWT compact serialization')
+        .and.notify(done)
     })
 
     it('should resolve a boolean', (done) => {


### PR DESCRIPTION
An update of the JWT/JWS to support the json general and flattened serializations.

This also partially contains some of the planned API update for JWT and JWS.

Currently tests are failing, although this is probably due to the API differences as mentioned above. Additional testing will be required for the newly supported serializations, although I imagine this will happen in the smith-linklater-jws-signing branch.