### PR TITLE
fix(JWKSet): Fix promise reject on validation errors

### DIFF
--- a/src/jose/JWKSet.js
+++ b/src/jose/JWKSet.js
@@ -30,16 +30,28 @@ class JWKSet extends JSONDocument {
     let validation = this.schema.validate(jwks)
 
     if (!validation.valid) {
-      Promise.reject(validation)
+      return Promise.reject(new Error('Invalid JWKSet: ' +
+        JSON.stringify(validation, null, 2)))
     }
 
-    let imported = new JWKSet(jwks)
-    let importing = jwks.keys.map(key => JWK.importKey(key))
+    if (!jwks.keys) {
+      return Promise.reject(new Error('Cannot import JWKSet: keys property is empty'))
+    }
 
-    return Promise.all(importing).then(keys => {
-      imported.keys = keys
-      return imported
-    })
+    let imported, importing
+
+    try {
+      imported = new JWKSet(jwks)
+      importing = jwks.keys.map(key => JWK.importKey(key))
+    } catch (err) {
+      return Promise.reject(err)
+    }
+
+    return Promise.all(importing)
+      .then(keys => {
+        imported.keys = keys
+        return imported
+      })
   }
 }
 

--- a/test/jose/JWKSetSpec.js
+++ b/test/jose/JWKSetSpec.js
@@ -15,6 +15,23 @@ let expect = chai.expect
  * Code under test
  */
 const JWKSet = require('../../src/jose/JWKSet')
+const JWKSetSchema = require('../../src/schemas/JWKSetSchema')
+
+const jwks1 = `{
+  "keys": [
+    {
+      "kid": "212OUymAqmI",
+      "kty": "RSA",
+      "alg": "RS256",
+      "n": "pQEhHEjUCw8Dj5h4wbPWCX1EC6OrcmIvr_ejZS4mWYPFnq8Q_GI_R63mALFD_LCZTrcd_LaG0irmbhAGaYOe8bYl8gvDEyVgH-nK8GkPSWaW_3DXazXM2cT2lWmHoRUi3Eh6ouG-hEEU7D2rwstfAsp30BRRjrJFVqgu4hx3INTMiFhFDrKBfec-SR2JCJwttB9Tj8I-AaJSBkFcA4Q3xaYmrc-b0j7cVrCBqt6cZXuwoDEdGf3d-1eTiywEWYKi4eiOfw5tonwrgNCtVPk-q150nz6IckmiweROzrY8Mj0xfmPwfNK-H1KciPZ6eRWeHJLPJWslCuVLbqwRpLQzhQ",
+      "e": "AQAB",
+      "key_ops": [
+        "verify"
+      ],
+      "ext": true
+    }
+  ]
+}`
 
 /**
  * Tests
@@ -26,7 +43,34 @@ describe('JWKSet', () => {
 
   describe('importKeys', () => {
     it('should return a promise')
-    it('should reject invalid JWK Set')
-    it('should resolve imported JWKs')
+
+    it('should reject invalid JWK Set', done => {
+      const invalidJwks = { keys: 'invalid' }
+
+      JWKSet.importKeys(invalidJwks)
+        .catch(error => {
+          expect(error).to.be.instanceOf(Error)
+          done()
+        })
+    })
+
+    it('should reject invalid JWK Set (no keys passed in)', done => {
+      const jwksNoKeys = {}
+
+      JWKSet.importKeys(jwksNoKeys)
+        .catch(error => {
+          expect(error).to.be.instanceOf(Error)
+          done()
+        })
+    })
+
+    it('should resolve imported JWKs', () => {
+      let validJwks = JSON.parse(jwks1)
+
+      return JWKSet.importKeys(validJwks)
+        .then(keys => {
+          expect(keys).to.exist
+        })
+    })
   })
 })


### PR DESCRIPTION
- On validation errors in `importKeys()`, adds a missing `return` statement to the `Promise.reject()`
- Rejects with an `Error` instead of a validation result object
- Handles cases where the `jwks.keys` property is empty/missing (was previously giving opaque
  `TypeError: Cannot read property 'map' of undefined` errors)