### PR TITLE
Result option

### DIFF
--- a/src/jose/JWT.js
+++ b/src/jose/JWT.js
@@ -592,7 +592,7 @@ class JWT extends JSONDocument {
 
       if (!result || result === 'string') {
         return this.serialize()
-      } else {
+      } else if (result === 'object' || result === 'instance') {
         return this
       }
     })

--- a/src/jose/JWT.js
+++ b/src/jose/JWT.js
@@ -510,7 +510,8 @@ class JWT extends JSONDocument {
       signatures,
       serialization,
       cryptoKey,
-      validate = true
+      validate = true,
+      result
     } = params
 
     if (validate) {
@@ -589,7 +590,11 @@ class JWT extends JSONDocument {
         }
       }
 
-      return this.serialize()
+      if (!result || result === 'string') {
+        return this.serialize()
+      } else {
+        return this
+      }
     })
   }
 


### PR DESCRIPTION
Respect the `result` option in `JWT`/`JWD` sign method calls.

`result` can either be `instance` or `string` and defaults to `string`.